### PR TITLE
Rename pkg to `opencodecounts`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: opencodes
+Package: opencodecounts
 Title: Clinical Code Usage in England
 Version: 0.0.2
 Authors@R: c(
@@ -26,8 +26,8 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-URL: https://github.com/bennettoxford/opencodes, https://bennettoxford.github.io/opencodes/
-BugReports: https://github.com/bennettoxford/opencodes/issues
+URL: https://github.com/bennettoxford/opencodecounts, https://bennettoxford.github.io/opencodecounts/
+BugReports: https://github.com/bennettoxford/opencodecounts/issues
 Imports: 
     bsicons,
     bslib,

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2024
-COPYRIGHT HOLDER: opencodes authors
+COPYRIGHT HOLDER: opencodecounts authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 opencodes authors
+Copyright (c) 2024 opencodecounts authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -1,4 +1,4 @@
-#' Run `opencodes` [Shiny App](https://milanwiedemann.shinyapps.io/opencodes/) locally
+#' Run `opencodecounts` [Shiny App](https://milanwiedemann.shinyapps.io/opencodecounts/) locally
 #'
 #' @export
 run_app <- function() {

--- a/R/server.R
+++ b/R/server.R
@@ -33,13 +33,13 @@ app_server <- function(input, output, session) {
     updateCheckboxInput(session, "show_individual_codes", value = FALSE)
 
     if (input$dataset == "snomedct") {
-      opencodes::snomed_usage |>
+      opencodecounts::snomed_usage |>
         select(start_date, end_date, code = snomed_code, description, usage)
     } else if (input$dataset == "icd10") {
-      opencodes::icd10_usage |>
+      opencodecounts::icd10_usage |>
         select(start_date, end_date, code = icd10_code, description, usage)
     } else if (input$dataset == "opcs4") {
-      opencodes::opcs4_usage |>
+      opencodecounts::opcs4_usage |>
         select(start_date, end_date, code = opcs4_code, description, usage)
     }
   })

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# opencodes
+# opencodecounts
 
 <!-- badges: start -->
 
@@ -21,8 +21,8 @@ knitr::opts_chunk$set(
 
 <!-- badges: end -->
 
-The goal of `opencodes` is to make yearly summaries of **SNOMED Code Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in Secondary Care** in England, published by NHS Digital, available in R for research.
-The interactive [OpenCodes Shiny App](https://bennettoxford.github.io/opencodes/articles/app.html) provides different options to explore these datasets.  
+The goal of `opencodecounts` is to make yearly summaries of **SNOMED Code Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in Secondary Care** in England, published by NHS Digital, available in R for research.
+The interactive [opencodecounts Shiny App](https://bennettoxford.github.io/opencodecounts/articles/app.html) provides different options to explore these datasets.  
 The original data is available from NHS Digital at:
 
 -   [SNOMED Code Usage in Primary Care](https://digital.nhs.uk/data-and-information/publications/statistical/mi-snomed-code-usage-in-primary-care)
@@ -30,13 +30,13 @@ The original data is available from NHS Digital at:
 
 ## Installation
 
-You can install the development version of `opencodes` like so:
+You can install the development version of `opencodecounts` like so:
 
 ``` r
-remotes::install_github("bennettoxford/opencodes")
+remotes::install_github("bennettoxford/opencodecounts")
 ```
 
-## Main functions of the `opencodes` R package
+## Main functions of the `opencodecounts` R package
 
 - **Datasets:**
   - `snomedct_usage`: SNOMED CT code usage dataset
@@ -44,13 +44,13 @@ remotes::install_github("bennettoxford/opencodes")
   - `opcs4_usage`: OPCS-4 code usage dataset
 - **Functions:**
    - `get_codelist()`: Imports a codelists from [www.opencodelists.org](https://www.opencodelists.org/)
-   - `run_app()`: Launches interactive OpenCodes Shiny App locally
+   - `run_app()`: Launches interactive opencodecounts Shiny App locally
 
 ## Example
 
 ```{r load-pkg}
-# Load opencodes package
-library(opencodes)
+# Load opencodecounts package
+library(opencodecounts)
 ```
 
 ### Dataset: SNOMED Code Usage in Primary Care in England

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# opencodes
+# opencodecounts
 
 <!-- badges: start -->
 
@@ -9,11 +9,11 @@
 
 <!-- badges: end -->
 
-The goal of `opencodes` is to make yearly summaries of **SNOMED Code
-Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in Secondary
-Care** in England, published by NHS Digital, available in R for
-research. The interactive [OpenCodes Shiny
-App](https://bennettoxford.github.io/opencodes/articles/app.html)
+The goal of `opencodecounts` is to make yearly summaries of **SNOMED
+Code Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in
+Secondary Care** in England, published by NHS Digital, available in R
+for research. The interactive [opencodecounts Shiny
+App](https://bennettoxford.github.io/opencodecounts/articles/app.html)
 provides different options to explore these datasets.  
 The original data is available from NHS Digital at:
 
@@ -24,13 +24,13 @@ The original data is available from NHS Digital at:
 
 ## Installation
 
-You can install the development version of `opencodes` like so:
+You can install the development version of `opencodecounts` like so:
 
 ``` r
-remotes::install_github("bennettoxford/opencodes")
+remotes::install_github("bennettoxford/opencodecounts")
 ```
 
-## Main functions of the `opencodes` R package
+## Main functions of the `opencodecounts` R package
 
 - **Datasets:**
   - `snomedct_usage`: SNOMED CT code usage dataset
@@ -39,13 +39,13 @@ remotes::install_github("bennettoxford/opencodes")
 - **Functions:**
   - `get_codelist()`: Imports a codelists from
     [www.opencodelists.org](https://www.opencodelists.org/)
-  - `run_app()`: Launches interactive OpenCodes Shiny App locally
+  - `run_app()`: Launches interactive opencodecounts Shiny App locally
 
 ## Example
 
 ``` r
-# Load opencodes package
-library(opencodes)
+# Load opencodecounts package
+library(opencodecounts)
 ```
 
 ### Dataset: SNOMED Code Usage in Primary Care in England
@@ -85,7 +85,7 @@ for the data pre-processing see `/data-raw/icd10_usage.R`.
 ``` r
 # Return ICD-10 code usage data
 icd10_usage
-#> # A tibble: 135,951 × 5
+#> # A tibble: 136,136 × 5
 #>    start_date end_date   icd10_code description                            usage
 #>    <date>     <date>     <chr>      <chr>                                  <int>
 #>  1 2023-04-01 2024-03-31 A000       Cholera due to Vibrio cholerae 01, bi…     2
@@ -98,7 +98,7 @@ icd10_usage
 #>  8 2023-04-01 2024-03-31 A020       Salmonella enteritis                    2165
 #>  9 2023-04-01 2024-03-31 A021       Salmonella sepsis                        319
 #> 10 2023-04-01 2024-03-31 A022       Localized salmonella infections           82
-#> # ℹ 135,941 more rows
+#> # ℹ 136,126 more rows
 ```
 
 ### Dataset: OPCS-4 Code Usage in Secondary Care in England
@@ -114,7 +114,7 @@ for the data pre-processing see `/data-raw/opcs4_usage.R`.
 ``` r
 # Return OPCS-4 code usage data
 opcs4_usage
-#> # A tibble: 107,376 × 5
+#> # A tibble: 107,379 × 5
 #>    start_date end_date   opcs4_code description                            usage
 #>    <date>     <date>     <chr>      <chr>                                  <int>
 #>  1 2023-04-01 2024-03-31 A011       Hemispherectomy                            7
@@ -127,5 +127,5 @@ opcs4_usage
 #>  8 2023-04-01 2024-03-31 A023       Excision of lesion of tissue of parie…   704
 #>  9 2023-04-01 2024-03-31 A024       Excision of lesion of tissue of occip…   260
 #> 10 2023-04-01 2024-03-31 A025       Excision of lesion of tissue of cereb…   604
-#> # ℹ 107,366 more rows
+#> # ℹ 107,369 more rows
 ```

--- a/data-raw/icd10_code_usage.R
+++ b/data-raw/icd10_code_usage.R
@@ -155,20 +155,20 @@ icd10_usage <- icd10_usage |>
   filter(!is.na(description))
 
 # Check encoding problems before fix
-codes_with_encoding_problems <- opencodes:::get_codes_with_encoding_problems(icd10_usage, icd10_code)
+codes_with_encoding_problems <- opencodecounts:::get_codes_with_encoding_problems(icd10_usage, icd10_code)
 # [1] "C841" "C880" "D510" "D511" "D513" "D518" "D519" "E672" "E750" "G375" "G610" "H810" "L705"
 # [14] "L813" "M350" "M352" "M911" "M931" "T470" "Y441" "Y530"
 
 # Fix encoding problems
 icd10_usage <- icd10_usage |>
-  mutate(description = opencodes:::fix_encoding(description))
+  mutate(description = opencodecounts:::fix_encoding(description))
 
 # Check encoding problems after fix
-opencodes:::get_codes_with_encoding_problems(icd10_usage, icd10_code)
+opencodecounts:::get_codes_with_encoding_problems(icd10_usage, icd10_code)
 # character(0)
 
 # Check (but dont fix) codes with multiple descriptions
-codes_with_multiple_desc <- opencodes:::get_codes_with_multiple_desc(icd10_usage, icd10_code)
+codes_with_multiple_desc <- opencodecounts:::get_codes_with_multiple_desc(icd10_usage, icd10_code)
 length(codes_with_multiple_desc)
 # [1] 214
 

--- a/data-raw/opcs4_code_usage.R
+++ b/data-raw/opcs4_code_usage.R
@@ -154,11 +154,11 @@ opcs4_usage <- opcs4_usage |>
   filter(!is.na(description))
 
 # Check encoding problems before fix
-codes_with_encoding_problems <- opencodes:::get_codes_with_encoding_problems(opcs4_usage, opcs4_code)
+codes_with_encoding_problems <- opencodecounts:::get_codes_with_encoding_problems(opcs4_usage, opcs4_code)
 # character(0)
 
 # Check (but dont fix) codes with multiple descriptions
-codes_with_multiple_desc <- opencodes:::get_codes_with_multiple_desc(opcs4_usage, opcs4_code)
+codes_with_multiple_desc <- opencodecounts:::get_codes_with_multiple_desc(opcs4_usage, opcs4_code)
 length(codes_with_multiple_desc)
 # [1] 99
 

--- a/data-raw/snomed_code_usage.R
+++ b/data-raw/snomed_code_usage.R
@@ -92,7 +92,7 @@ snomed_usage |>
 # A tibble: 0 × 3
 
 # Check encoding problems before fix
-codes_with_encoding_problems <- opencodes:::get_codes_with_encoding_problems(snomed_usage, snomed_code)
+codes_with_encoding_problems <- opencodecounts:::get_codes_with_encoding_problems(snomed_usage, snomed_code)
 # [1] "1011271000000107"   "1011311000000107"   "13445001"           "83901003"           "40956001"           "201281002"
 # [7] "190818004"          "111303009"          "43234007"           "150091000000106"    "266994001"          "313005"
 # [13] "275542004"          "408521009"          "236504007"          "239912009"          "27982003"           "75895005"
@@ -110,14 +110,14 @@ codes_with_encoding_problems <- opencodes:::get_codes_with_encoding_problems(sno
 
 # Fix encoding problems
 snomed_usage <- snomed_usage |>
-  mutate(description = opencodes:::fix_encoding(description))
+  mutate(description = opencodecounts:::fix_encoding(description))
 
 # Check encoding problems after fix
-opencodes:::get_codes_with_encoding_problems(snomed_usage, snomed_code)
+opencodecounts:::get_codes_with_encoding_problems(snomed_usage, snomed_code)
 # character(0)
 
 # Check (but dont fix) codes with multiple descriptions
-codes_with_multiple_desc <- opencodes:::get_codes_with_multiple_desc(snomed_usage, snomed_code)
+codes_with_multiple_desc <- opencodecounts:::get_codes_with_multiple_desc(snomed_usage, snomed_code)
 length(codes_with_multiple_desc)
 # [1] 8520
 

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -2,10 +2,10 @@
 % Please edit documentation in R/run_app.R
 \name{run_app}
 \alias{run_app}
-\title{Run \code{opencodes} \href{https://milanwiedemann.shinyapps.io/opencodes/}{Shiny App} locally}
+\title{Run \code{opencodecounts} \href{https://milanwiedemann.shinyapps.io/opencodecounts/}{Shiny App} locally}
 \usage{
 run_app()
 }
 \description{
-Run \code{opencodes} \href{https://milanwiedemann.shinyapps.io/opencodes/}{Shiny App} locally
+Run \code{opencodecounts} \href{https://milanwiedemann.shinyapps.io/opencodecounts/}{Shiny App} locally
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,6 +7,6 @@
 # * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
-library(opencodes)
+library(opencodecounts)
 
-test_check("opencodes")
+test_check("opencodecounts")

--- a/vignettes/app.Rmd
+++ b/vignettes/app.Rmd
@@ -23,6 +23,6 @@ vignette: >
 </style>
 
 <div class="shiny-app-frame"> 
-<iframe src="https://milanwiedemann.shinyapps.io/opencodes/">
+<iframe src="https://milanwiedemann.shinyapps.io/opencodecounts/">
 </iframe>
 </div>


### PR DESCRIPTION
Closes #72

Not saying that this will be the new name, just identified all changes we need to make so that it's easier once we pick a new pkg name.