### PR TITLE
Change small numbers supression

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: end -->
 
-The goal of `opencodecounts` is to make yearly summaries of **SNOMED Code Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in Secondary Care** in England, published by NHS Digital, available in R for research.
+The goal of `opencodecounts` is to make yearly summaries of **SNOMED Code Usage in Primary Care** and **ICD-10 and OPCS-4 Code Usage in Secondary Care** in England, published by NHS, available in R for research.
 The interactive [opencodecounts Shiny App](https://bennettoxford.github.io/opencodecounts/articles/app.html) provides different options to explore these datasets.  
 The original data is available from NHS Digital at:
 

--- a/data-raw/icd10_code_usage.R
+++ b/data-raw/icd10_code_usage.R
@@ -135,9 +135,9 @@ icd10_usage <- icd10_code_usage_urls |>
 sum(is.na(icd10_usage$usage))
 # [1] 323
 
-# Replace NAs with 10
+# Replace NAs with 5
 icd10_usage <- icd10_usage |>
-  mutate(usage = replace_na(usage, 10))
+  mutate(usage = replace_na(usage, 5))
 
 # Check number of usage with NAs is 0
 sum(is.na(icd10_usage$usage)) == 0

--- a/data-raw/opcs4_code_usage.R
+++ b/data-raw/opcs4_code_usage.R
@@ -134,9 +134,9 @@ opcs4_usage <- opcs4_code_usage_urls |>
 sum(is.na(opcs4_usage$usage))
 # [1] 143
 
-# Replace NAs with 10
+# Replace NAs with 5
 opcs4_usage <- opcs4_usage |>
-  mutate(usage = replace_na(usage, 10))
+  mutate(usage = replace_na(usage, 5))
 
 # Check number of usage with NAs is 0
 sum(is.na(opcs4_usage$usage)) == 0

--- a/data-raw/snomed_code_usage.R
+++ b/data-raw/snomed_code_usage.R
@@ -70,9 +70,9 @@ snomed_usage <- snomed_code_usage_urls %>%
 sum(is.na(snomed_usage$usage))
 # [1] 406178
 
-# Replace NAs with 10
+# Replace NAs with 5
 snomed_usage <- snomed_usage |>
-  mutate(usage = replace_na(usage, 10))
+  mutate(usage = replace_na(usage, 5))
 
 # Check number of usage with NAs is 0
 sum(is.na(snomed_usage$usage)) == 0


### PR DESCRIPTION
Feedback received for the tool (Helen C.):



> Just using the code count tool to look at differences between some codelists and I wonder if the small numbers (1-4)  could be converted to 5 rather than 10? It might not be obvious to users that a total count of say 100 in the tool could be actually 100ish if there are no suppressed figures, or, if it's entirely comprised of suppressed figures it could be as little as 10 (ie 1 code occurrence in each of 10 years), or up to 40. Using 5 would firstly give a closer estimation of the true figure, and the fact there are numbers that are not multiples of 10 would stand out more to users that the small numbers are a bit different

Internal agreement that 10s throughout can be misleading re actual code occurrence.

Also removing NHS "Digital" as it was disassembled.  